### PR TITLE
Promote to prod environment

### DIFF
--- a/components/go-whbozfdi/overlays/prod/deployment-patch.yaml
+++ b/components/go-whbozfdi/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-whbozfdi:github-5ec4b1d3cbd4d9e179fe8f260e69a0ca8ca65ed7
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-whbozfdi:github-5ec4b1d3cbd4d9e179fe8f260e69a0ca8ca65ed7